### PR TITLE
improve colorizer

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,6 +11,10 @@ This is a wiki-style link to the [[EZ_FAKE]] page, which doesn't exist yet.
 
 This is an external link to the [hackmud website](https://hackmud.com).
 
-trust.me
+{{ ~X>>trust.me {key: "value", key: {}, key: #s.mallory.starchart, amount: "1KGC"}~ }}
 
-dtr.man
+{{ 1TGC }}
+
+{{ 1K337GC }}
+
+{{ 1Q1T1B1M1K1GC }}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,19 +14,89 @@
 .inline-script {
     font-family: 'White Rabbit';
 }
-.color-trust {
-    color: orange;
-}
-.color-user {
-    color: grey;
-}
-.color-script {
-    color: green;
-}
 
+.color-trust {color: #ff8000;}
+.color-user {color: #9b9b9b;}
+.color-script {color: #1eff00;}
+
+.color-cli {color: #ffffff;}
+
+.color-gc-text {color: #cacaca;}
+.color-gc-q {color: #ff0000;}
+.color-gc-t {color: #ff00ec;}
+.color-gc-b {color: #fff404;}
+.color-gc-m {color: #1eff00;}
+.color-gc-k {color: #00ffff;}
+.color-gc-end {color: #9b9b9b;}
+
+.color-key {color: #00ffff;}
+.color-value {color: #ff00ec;}
+
+.color-tag[tag="0"] {color: #9b9b9b;}
+.color-tag[tag="1"] {color: #ffffff;}
+.color-tag[tag="2"] {color: #1eff00;}
+.color-tag[tag="3"] {color: #0070dd;}
+.color-tag[tag="4"] {color: #b035ee;}
+.color-tag[tag="5"] {color: #ff8000;}
+.color-tag[tag="6"] {color: #ff8000;}
+.color-tag[tag="7"] {color: #ff8000;}
+.color-tag[tag="8"] {color: #ff8000;}
+.color-tag[tag="9"] {color: #ff8000;}
+.color-tag[tag="a"] {color: #000000;}
+.color-tag[tag="b"] {color: #3f3f3f;}
+.color-tag[tag="c"] {color: #676767;}
+.color-tag[tag="d"] {color: #7d0000;}
+.color-tag[tag="e"] {color: #8e3434;}
+.color-tag[tag="f"] {color: #a34f00;}
+.color-tag[tag="g"] {color: #725437;}
+.color-tag[tag="h"] {color: #a88600;}
+.color-tag[tag="i"] {color: #b2934a;}
+.color-tag[tag="j"] {color: #939500;}
+.color-tag[tag="k"] {color: #495225;}
+.color-tag[tag="l"] {color: #299400;}
+.color-tag[tag="m"] {color: #23381b;}
+.color-tag[tag="n"] {color: #00535b;}
+.color-tag[tag="o"] {color: #324a4c;}
+.color-tag[tag="p"] {color: #0073a6;}
+.color-tag[tag="q"] {color: #385a6c;}
+.color-tag[tag="r"] {color: #010067;}
+.color-tag[tag="s"] {color: #507aa1;}
+.color-tag[tag="t"] {color: #601c81;}
+.color-tag[tag="u"] {color: #43314c;}
+.color-tag[tag="v"] {color: #8c0069;}
+.color-tag[tag="w"] {color: #973984;}
+.color-tag[tag="x"] {color: #880024;}
+.color-tag[tag="y"] {color: #762e4a;}
+.color-tag[tag="z"] {color: #101215;}
+.color-tag[tag="A"] {color: #ffffff;}
+.color-tag[tag="B"] {color: #cacaca;}
+.color-tag[tag="C"] {color: #9b9b9b;}
+.color-tag[tag="D"] {color: #ff0000;}
+.color-tag[tag="E"] {color: #ff8383;}
+.color-tag[tag="F"] {color: #ff8000;}
+.color-tag[tag="G"] {color: #f3aa6f;}
+.color-tag[tag="H"] {color: #fbc803;}
+.color-tag[tag="I"] {color: #ffd863;}
+.color-tag[tag="J"] {color: #fff404;}
+.color-tag[tag="K"] {color: #f3f998;}
+.color-tag[tag="L"] {color: #1eff00;}
+.color-tag[tag="M"] {color: #b3ff9b;}
+.color-tag[tag="N"] {color: #00ffff;}
+.color-tag[tag="O"] {color: #8fe6ff;}
+.color-tag[tag="P"] {color: #0070dd;}
+.color-tag[tag="Q"] {color: #a4e3ff;}
+.color-tag[tag="R"] {color: #0000ff;}
+.color-tag[tag="S"] {color: #7ab2f4;}
+.color-tag[tag="T"] {color: #b035ee;}
+.color-tag[tag="U"] {color: #e6c4ff;}
+.color-tag[tag="V"] {color: #ff00ec;}
+.color-tag[tag="W"] {color: #ff96e0;}
+.color-tag[tag="X"] {color: #ff0070;}
+.color-tag[tag="Y"] {color: #ff6a98;}
+.color-tag[tag="Z"] {color: #0c112b;}
 
 /**
- * WIKILINK PLUGIN RELATD CLASSES
+ * WIKILINK PLUGIN RELATED CLASSES
  */
  /*a.wikilink {
 

--- a/src/plugins/remark/color.js
+++ b/src/plugins/remark/color.js
@@ -2,24 +2,82 @@ module.exports = async function() {
     // Importing from ESM modules into CommonJS space
     const { findAndReplace } = await import('mdast-util-find-and-replace');
     const { u } = await import ('unist-builder');
+
     // Constants
     const trustUsers = ['accts', 'autos', 'binmat', 'chats', 'corps', 'escrow', 'gui', 'kernel', 'market', 'scripts', 'sys', 'trust', 'users'];
-    const scriptRegex = new RegExp(/\b([a-z_][a-z0-9_]{0,24})\.([a-z_][a-z0-9_]{0,24})\b/gi);
-    // Return plugin callable, which accepts a (currently unused) config object
-    return (config) => {
-        // Replacer function
-        function textToColoredSpan(text, user, script) {
-            const isTrust = trustUsers.includes(user);
-            return u('html',
-                `<span class="inline-script"><span class="color-${isTrust ? 'trust' : 'user'}">${user}</span>` +
-                '.' +
-                `<span class="color-script">${script}</span></span>`
-            );
+    const autocolorRegex = /\{\{(.*?)\}\}/g;
+    const scriptRegex = /\b(?<!#)([a-z_][a-z0-9_]{0,24})\.([a-z_][a-z0-9_]{0,24})\b/gi;
+    const colorTagRegex = /~([0-9a-zA-z])(.+?)~/g;
+    const kvpRegex = /(\w+)[ ]*:[ ]*(?:(".*?"|\d+(?:\.\d*)?|null|true|false|#s\.\w+\.\w+)|(?=\{|\[))/g;
+    const gcRegex = /(?=\d)(?:(\d+)Q)?(?:(\d{1,3})T)?(?:(\d{1,3})B)?(?:(\d{1,3})M)?(?:(\d{1,3})K)?(\d{1,3})?GC/g;
+
+    // Replacer functions
+
+    function scriptColoring(_fullMatch, user, script) {
+        const isTrust = trustUsers.includes(user);
+        return `<span class="color-${isTrust ? 'trust' : 'user'}">${user}</span>` +
+            '.' +
+            `<span class="color-script">${script}</span>`;
+    }
+
+    function colorTagReplacer(_fullMatch, tag, inner) {
+        return `<span class="color-tag" tag="${tag}">${inner}</span>`;
+    }
+
+    function kvpReplacer(_fullMatch, key, value) {
+        if (!value) {
+            return `<span class="color-key">${key}</span>: `;
+        } else {
+            return `<span class="color-key">${key}</span>: <span class="color-value">${value}</span>`;
         }
+    }
+
+    function gcReplacer(_fullMatch, q, t, b, m, k, units) {
+        const out = []
+
+        const letters_and_values = [
+            ["q", q],
+            ["t", t],
+            ["b", b],
+            ["m", m],
+            ["k", k],
+        ];
+
+        for (const [letter, value] of letters_and_values) {
+            if (value) {
+                out.push(`<span class="color-gc-text">${value}</span><span class="color-gc-${letter}">${letter.toUpperCase()}</span>`);
+            }
+        }
+
+        if (units) {
+            out.push(`<span class="color-gc-text">${units}</span>`);
+        }
+
+        out.push(`<span class="color-gc-end">GC</span>`)
+
+        return out.join("")
+    }
+
+    function colorizeContent(_fullMatch, content) {
+        const passes = [
+            {regex: colorTagRegex, replacer: colorTagReplacer},
+            {regex: kvpRegex, replacer: kvpReplacer},
+            {regex: scriptRegex, replacer: scriptColoring},
+            {regex: gcRegex, replacer: gcReplacer},
+        ];
+
+        for (const {regex, replacer} of passes) {
+            content = content.replace(regex, replacer);
+        }
+
+        return u("html", `<span>${content}</span>`);
+    }
+
+    // Return plugin callable, which accepts a (currently unused) config object
+    return (_config) => {
         // Function that acts on the AST
         return ast => {
-            findAndReplace(ast, [scriptRegex, textToColoredSpan]);
-            //findAndReplace(ast, [/\b([a-z_][a-z0-9_]{0,24})\.([a-z_][a-z0-9_]{0,24})\b/gi, textToColoredSpan])
+            findAndReplace(ast, [autocolorRegex, colorizeContent]);
         }
     }
 }

--- a/src/plugins/remark/color.js
+++ b/src/plugins/remark/color.js
@@ -5,10 +5,31 @@ module.exports = async function() {
 
     // Constants
     const trustUsers = ['accts', 'autos', 'binmat', 'chats', 'corps', 'escrow', 'gui', 'kernel', 'market', 'scripts', 'sys', 'trust', 'users'];
+
+    // Matches {{ <content> }}
     const autocolorRegex = /\{\{(.*?)\}\}/g;
+
+    // Matches <user>.<script> *except* when preceeded by a #
+    // This is so that in #s.<user>.<script>, the s.<user> portion won't be colored
     const scriptRegex = /\b(?<!#)([a-z_][a-z0-9_]{0,24})\.([a-z_][a-z0-9_]{0,24})\b/gi;
+
+    // Matches ~<one character long color tag><content>~
     const colorTagRegex = /~([0-9a-zA-z])(.+?)~/g;
-    const kvpRegex = /(\w+)[ ]*:[ ]*(?:(".*?"|\d+(?:\.\d*)?|null|true|false|#s\.\w+\.\w+)|(?=\{|\[))/g;
+
+    // Matches <key>: <value> with an arbitrary amount of spaces around the :
+
+    // Key can either be a word like some_parameter:
+    // or a quoted string like "this is multiple words":
+
+    // Values can be strings, numbers, null, true, false, or scriptors
+    // This will also match <key>: { or <key>: [ but will NOT include the { or [ in the match to be colorized
+    const kvpRegex = /(\w+|".*?")[ ]*:[ ]*(?:(".*?"|\d+(?:\.\d*)?|null|true|false|#s\.\w+\.\w+)|(?=\{|\[))/g;
+
+    // Matches GC strings, e.g. 1Q1T1B1M1K1GC
+    // Explicitly does NOT match the text GC on its own
+
+    // Notably, this only matches uppercase GC strings currently
+    // This can be changed by adding an i to the regex flags, but lowercase strings will still be converted to uppercase when colorized
     const gcRegex = /(?=\d)(?:(\d+)Q)?(?:(\d{1,3})T)?(?:(\d{1,3})B)?(?:(\d{1,3})M)?(?:(\d{1,3})K)?(\d{1,3})?GC/g;
 
     // Replacer functions
@@ -33,7 +54,7 @@ module.exports = async function() {
     }
 
     function gcReplacer(_fullMatch, q, t, b, m, k, units) {
-        const out = []
+        const out = [];
 
         const letters_and_values = [
             ["q", q],
@@ -53,13 +74,15 @@ module.exports = async function() {
             out.push(`<span class="color-gc-text">${units}</span>`);
         }
 
-        out.push(`<span class="color-gc-end">GC</span>`)
+        out.push(`<span class="color-gc-end">GC</span>`);
 
-        return out.join("")
+        return out.join("");
     }
 
     function colorizeContent(_fullMatch, content) {
         const passes = [
+            // Note that the order of replacements here is important, and shuffling it may cause breakage
+
             {regex: colorTagRegex, replacer: colorTagReplacer},
             {regex: kvpRegex, replacer: kvpReplacer},
             {regex: scriptRegex, replacer: scriptColoring},
@@ -70,6 +93,8 @@ module.exports = async function() {
             content = content.replace(regex, replacer);
         }
 
+        // As far as the author knows, the content of an mdast html node must be contained within a single root html tag
+        // We wrap the content in an unstyled span tag so that this requirement is met
         return u("html", `<span>${content}</span>`);
     }
 


### PR DESCRIPTION
* Added {{ }} tags to explicitly do autocoloring.
* Added GC coloring.
* Added key-value pair coloring.
* Added manual coloring, but using ~ instead of \`. This is because text wrapped in \`s seemingly gets parsed as a inline code block before we gain access to the AST and iterate over it so I selected another character. It would be good to fix this somehow but I don't know how.

Honestly, the way this implements coloring (doing regex passes in a specific order and nesting span tags) seems pretty fragile. It would be nice to have a better system for doing this but I hope this will work for now.
